### PR TITLE
update with 1.0.2 Operator versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ To find out more, read the [release notes](https://www.ibm.com/docs/en/SSV97FN_2
 
 |  Supported Operator versions |
 |-| 
+| [1.0.2](https://github.com/IBM/zos_opencpp_operator/releases/tag/v1.0.2) | 
 | [1.0.1](https://github.com/IBM/zos_opencpp_operator/releases/tag/v1.0.1) | 
 | [1.0.0](https://github.com/IBM/zos_opencpp_operator/releases/tag/v1.0.0) |
 
@@ -41,6 +42,7 @@ To find out more, read the [release notes](https://www.ibm.com/docs/en/SSV97FN_2
 
 | Supported Operator versions | 
 |-|
+| [1.0.2](https://github.com/IBM/zos_java_operator/releases/tag/v1.0.2) | 
 | [1.0.1](https://github.com/IBM/zos_java_operator/releases/tag/v1.0.1) | 
 | [1.0.0](https://github.com/IBM/zos_java_operator/releases/tag/v1.0.0) | 
 
@@ -56,6 +58,7 @@ To find out more, read the [release notes](https://www.ibm.com/docs/en/SSV97FN_2
 
  Supported Operator versions |
 |-| 
+| [1.0.2](https://github.com/IBM/zos_go_operator/releases/tag/v1.0.2) | 
 | [1.0.1](https://github.com/IBM/zos_go_operator/releases/tag/v1.0.1) | 
 | [1.0.0](https://github.com/IBM/zos_go_operator/releases/tag/v1.0.0) | 
 
@@ -69,6 +72,7 @@ To find out more, read the [release notes](https://www.ibm.com/docs/en/SSV97FN_2
 
 | Supported Operator versions | 
 |-|
+| [1.0.2](https://github.com/IBM/zos_nodejs_operator/releases/tag/v1.0.2) |
 | [1.0.1](https://github.com/IBM/zos_nodejs_operator/releases/tag/v1.0.1) |
 | [1.0.0](https://github.com/IBM/zos_nodejs_operator/releases/tag/v1.0.0) | 
 
@@ -82,6 +86,7 @@ To find out more, read the [release notes](https://www.ibm.com/docs/en/SSV97FN_2
 
 | Supported Operator versions | 
 |-| 
+| [1.0.2](https://github.com/IBM/zos_python_operator/releases/tag/v1.0.2) | 
 | [1.0.1](https://github.com/IBM/zos_python_operator/releases/tag/v1.0.1) | 
 | [1.0.0](https://github.com/IBM/zos_python_operator/releases/tag/v1.0.0) | 
 
@@ -94,5 +99,6 @@ To find out more, read the [release notes](https://www.ibm.com/docs/en/SSV97FN_2
 
 | Supported Operator versions | 
 |-| 
+| [1.0.2](https://github.com/IBM/zos_zoau_operator/releases/tag/v1.0.2) |
 | [1.0.1](https://github.com/IBM/zos_zoau_operator/releases/tag/v1.0.1) |
 | [1.0.0](https://github.com/IBM/zos_zoau_operator/releases/tag/v1.0.0) |


### PR DESCRIPTION
Update readme with links to 1.0.2 operator collections. 

Signed-off-by: BRYANT PANYARACHUN <bpanyarachun@gmail.com>